### PR TITLE
Require main queue setup

### DIFF
--- a/ios/ColorPicker.swift
+++ b/ios/ColorPicker.swift
@@ -8,6 +8,11 @@ class ColorPickerProxy: UIViewController, UIColorPickerViewControllerDelegate {
     var callback: RCTResponseSenderBlock!
 
     @objc
+    static func requiresMainQueueSetup() -> Bool {
+        return true
+    }
+
+    @objc
     func showColorPicker(_ options:NSDictionary, callback:@escaping RCTResponseSenderBlock){
         if (options["supportsAlpha"] as? NSNumber == 1) {
             self.supportsAlpha = true

--- a/ios/ColorPickerIos.m
+++ b/ios/ColorPickerIos.m
@@ -4,6 +4,11 @@
 
 @interface RCT_EXTERN_MODULE(RNCColorPicker, NSObject)
 
++ (BOOL)requiresMainQueueSetup
+{
+    return YES;
+}
+
 RCT_EXTERN_METHOD(showColorPicker:(NSDictionary*)options callback:(RCTResponseSenderBlock*)callback)
 
 @end

--- a/ios/ColorPickerIos.m
+++ b/ios/ColorPickerIos.m
@@ -4,11 +4,6 @@
 
 @interface RCT_EXTERN_MODULE(RNCColorPicker, NSObject)
 
-+ (BOOL)requiresMainQueueSetup
-{
-    return YES;
-}
-
 RCT_EXTERN_METHOD(showColorPicker:(NSDictionary*)options callback:(RCTResponseSenderBlock*)callback)
 
 @end


### PR DESCRIPTION
Stops this warning:

```
Module RNCColorPicker requires main queue setup since it overrides `init` but doesn't implement `requiresMainQueueSetup`. In a future release React Native will default to initializing all native modules on a background thread unless explicitly opted-out of.
```